### PR TITLE
feat: auto tag & release. Optionally push to ghcr

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,13 +6,38 @@ on:
     tags: ["*"]
 
 env:
+  APP_NAME: aqe
   IMAGE_NAME: ugwuanyi/aqe
   TEST_IMAGE: aqe/test
 
 jobs:
-  buildDockerImage:
-    name: Build docker image
+  prebuild:
+    name: prebuild
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    name: Build docker image
+    needs: [prebuild]
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    env: 
+      REGISTRY_DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_USERNAME != null }}
+      REGISTRY_GITHUB_ENABLED: ${{ secrets.REGISTRY_GITHUB != null }}
     steps:
       - uses: actions/checkout@v3
 
@@ -30,7 +55,16 @@ jobs:
         run: curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && chmod +x container-structure-test-linux-amd64 && sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
 
       - name: Login to DockerHub Registry
+        if: ${{ env.REGISTRY_DOCKERHUB_ENABLED == 'true' }}
         run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Login to Github Container Registry
+        if: ${{ env.REGISTRY_GITHUB_ENABLED == 'true' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Test image
         run: docker build -t ${{ env.TEST_IMAGE }} -f docker/Dockerfile .
@@ -38,9 +72,52 @@ jobs:
       - name: Run Image tests
         run: container-structure-test test --config docker/tests.yaml --image ${{ env.TEST_IMAGE }}
 
-      - name: Build and Publish docker image
-        run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${{ env.IMAGE_NAME }}:${{ github.ref_name }} -f docker/Dockerfile --push .
+      - name: Build app image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          load: true
+          file: "docker/Dockerfile"
+          platforms: linux/amd64
 
-      - name: Build and Publish docker image for tags
-        if: github.ref_type == 'tag'
-        run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${{ env.IMAGE_NAME }}:latest -f docker/Dockerfile --push .
+      - name: Push to dockerhub
+        if: ${{ env.REGISTRY_DOCKERHUB_ENABLED == 'true' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: "docker/Dockerfile"
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            "${{ env.IMAGE_NAME }}:latest"
+            "${{ env.IMAGE_NAME }}:${{ needs.prebuild.outputs.new_tag }}"
+
+      - name: Push to ghcr
+        if: ${{ env.REGISTRY_GITHUB_ENABLED == 'true' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: "docker/Dockerfile"
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            "${{ secrets.REGISTRY_GITHUB }}/${{ env.APP_NAME }}:latest"
+            "${{ secrets.REGISTRY_GITHUB }}/${{ env.APP_NAME }}:${{ needs.prebuild.outputs.new_tag }}"
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: [ prebuild, build ]
+    permissions: 
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.prebuild.outputs.new_tag }}
+          name: Release ${{ needs.prebuild.outputs.new_tag }}
+          body: ${{ needs.prebuild.outputs.changelog }}
+          generateReleaseNotes: true


### PR DESCRIPTION
## Linked Issue

closes #123 

## Describe changes
This pull request enhances the GitHub Actions workflow in the following manner:
 - **Automatic Version Bumping**: The [github-tag-action](https://github.com/mathieudutour/github-tag-action) is now integrated to facilitate automatic version incrementing.
- **Optional GitHub Registry Push**: Optionally push to github registry. When secret `REGISTRY_GITHUB` with value `ghcr.io/<user-name>` exists.
-  **Docker Image Tagging**: Docker images are now tagged with the current version.
- **Release Creation with Changelog**: Following a successful build, a release is automatically generated and includes a changelog

## Pull Request Checklist
<!--
    Run through this checklist when submitting a PR.
    Each item should be ticked off by you or a reviewer before it gets merged.
    You can click on the checkbox to do this.
-->

- [ ] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [ ] Run `pre-commit run -a` on your branch
- [ ] Update your branch `git merge main`
- [ ] Update documentation
