### PR TITLE
fix: use regex with invalid characters instead of replacer

### DIFF
--- a/pkg/collector.go
+++ b/pkg/collector.go
@@ -11,25 +11,8 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-var replacer = strings.NewReplacer(
-	" ", "_",
-	",", "_",
-	"\t", "_",
-	"/", "_",
-	"\\", "_",
-	".", "_",
-	"-", "_",
-	":", "_",
-	"=", "_",
-	"“", "_",
-        "'", "_",
-	"@", "_",
-	"<", "_",
-	">", "_",
-	"%", "_percent",
-	"(", "",
-	")", "",
-)
+var invalidPrometheusChars = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
 var splitRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 var logGroup = slog.Group("request",
 	slog.String("method", "GET"),
@@ -160,7 +143,7 @@ func PromStringTag(text string, labelsSnakeCase bool) (bool, string) {
 }
 
 func sanitize(text string) string {
-	return replacer.Replace(text)
+	return invalidPrometheusChars.ReplaceAllString(text, "_")
 }
 
 func splitString(text string) string {

--- a/pkg/collector_test.go
+++ b/pkg/collector_test.go
@@ -43,3 +43,42 @@ func Test_createDesc(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitize(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"allowed_only_09AZ", "allowed_only_09AZ"},
+		{"!@#$%^&*()'’", "____________"},
+		{"CamelCaseAllowedOnly", "CamelCaseAllowedOnly"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := sanitize(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected: %s, Got: %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestPromString(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"SomeText@Here123", "some_text_here123"},
+		{"!@#$%^&*()'’", "____________"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := PromString(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected: %s, Got: %s", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Linked Issue
closes #125 

## Describe changes
We can't put all invalid characters in replacer. But we can use regex to replace all invalid characters with underscores. 
- This PR adds regex string substitution in place of `replacer`
- Also, I've added a few test to check correctness of the sanitizer 

## Pull Request Checklist

<!--
    Run through this checklist when submitting a PR.
    Each item should be ticked off by you or a reviewer before it gets merged.
    You can click on the checkbox to do this.
-->

- [ ] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [ ] Run `pre-commit run -a` on your branch
- [ ] Update your branch `git merge main`
- [ ] Update documentation
