### PR TITLE
fix: correctly validate whether given role string is a valid ARN and a role

### DIFF
--- a/pkg/scrapper.go
+++ b/pkg/scrapper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -150,11 +151,11 @@ func validateRoleARN(role string) bool {
 		if err != nil {
 			return false
 		}
-		if arnObj.Resource != "role" {
-			return false
+		if strings.HasPrefix(arnObj.Resource, "role/") {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // Transform to prometheus format

--- a/pkg/scrapper_test.go
+++ b/pkg/scrapper_test.go
@@ -92,3 +92,37 @@ func TestScraper_CreateScraper(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateRoleARN(t *testing.T) {
+	type args struct {
+		role string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Valid role ARN",
+			args: args{role: "arn:aws:iam::012345678901:role/aws-quota-exporter"},
+			want: true,
+		},
+		{
+			name: "Invalid role ARN",
+			args: args{role: "arn:aws:iam::012345678901:user/aws-quota-exporter"},
+			want: false,
+		},
+		{
+			name: "Not an ARN",
+			args: args{role: "foo"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateRoleARN(tt.args.role); got != tt.want {
+				t.Errorf("validateRoleARN() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe changes

The role ARN validation was failing due to "role" being just a prefix in the `arnObj.Resource` (the resource contains the role name after a slash). Once I've added some tests I realised it was also incorrectly validating non-ARN strings as valid roles so fixed that too :)


## Pull Request Checklist

- [x] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [ ] Run `pre-commit run -a` on your branch
  - go-lint is now deprecated and frozen so I skipped that particular hook
- [x] Update your branch `git merge main`
- [ ] Update documentation
  - not needed
