### PR TITLE
fix: error, rather than panic, when (eg. due to permission issues) a particular job metric cannot be registered

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,10 @@ func main() {
 	slog.Info("Registering scrappers")
 	for _, job := range qcl.Jobs {
 		pc := pkg.NewPrometheusCollector(s.CreateScraper(job, *cacheDuration))
-		reg.MustRegister(pc)
+		err := reg.Register(pc)
+		if err != nil {
+			slog.Error("Failed to register metrics: "+err.Error(), "serviceCode", job.ServiceCode, "regions", job.Regions, "role", job.Role)
+		}
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Describe changes

`MustRegister` takes in a function which can return errors and then executes it. If an error is returned, `panic()` is called and the exporter halts. This means that if there are any jobs in the config file for which the required permissions are missing, the exporter will fail to start. This PR uses `Register` and checks the error value instead so that in case of an un-scrapable job in the config the exporter can still start and register (and later on serve) other metrics.

## Pull Request Checklist

- [x] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [ ] Run `pre-commit run -a` on your branch
  - go-lint is now deprecated and frozen so I skipped that particular hook
- [x] Update your branch `git merge main`
- [ ] Update documentation
  - not needed