### PR TITLE
fix: use unique filenames for caches across different jobs

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,14 +84,6 @@ func main() {
 	// Handle keyboard interrupt
 	closeHandler()
 
-	// check if cache folder exists
-	if _, err := os.Stat(pkg.CacheFolder); os.IsNotExist(err) {
-		err = os.MkdirAll(pkg.CacheFolder, 0755)
-		if err != nil {
-			slog.Error("Error creating cache folder", "error", err)
-		}
-	}
-
 	// Make Prometheus client aware of our collectors.
 	qcl, err := pkg.NewQuotaConfig(*configFile)
 	if err != nil {
@@ -107,8 +99,9 @@ func main() {
 	reg := prometheus.NewRegistry()
 	slog.Info("Registering scrappers")
 	for _, job := range qcl.Jobs {
-		pc := pkg.NewPrometheusCollector(s.CreateScraper(job, *cacheDuration))
-		err := reg.Register(pc)
+
+		pc := pkg.NewPrometheusCollector(s.CreateScraper(job, cacheDuration))
+		err = reg.Register(pc)
 		if err != nil {
 			slog.Error("Failed to register metrics: "+err.Error(), "serviceCode", job.ServiceCode, "regions", job.Regions, "role", job.Role)
 		}

--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -22,12 +22,25 @@ var (
 )
 
 // NewCache creates a new Cache instance
-func NewCache(fileName string, lifeTime time.Duration) *Cache {
+func NewCache(fileName string, lifeTime time.Duration) (*Cache, error) {
+	// check if cache folder exists
+	if _, err := os.Stat(CacheFolder); os.IsNotExist(err) {
+		err = os.MkdirAll(CacheFolder, 0755)
+		if err != nil {
+			return nil, errors.New("Error creating cache folder: " + err.Error())
+		}
+	}
+
+	f, err := os.CreateTemp(CacheFolder, fileName+"-*.json")
+	if err != nil {
+		return nil, errors.New("Could not initialise cache for " + fileName + ": " + err.Error())
+	}
+
 	return &Cache{
-		FileName: CacheFolder + fileName,
+		FileName: f.Name(),
 		LifeTime: time.Second * lifeTime,
 		Expires:  time.Now(),
-	}
+	}, nil
 }
 
 // Read reads the contents of the cache file

--- a/pkg/cache_test.go
+++ b/pkg/cache_test.go
@@ -1,7 +1,7 @@
 package pkg
 
 import (
-	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -31,7 +31,14 @@ func TestNewCache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewCache(tt.args.fileName, tt.args.lifeTime); !reflect.DeepEqual(got.FileName, tt.want.FileName) {
+			var err error
+			got, err := NewCache(tt.args.fileName, tt.args.lifeTime)
+
+			if err != nil {
+				t.Error("NewCache() errored out: ", err.Error())
+			}
+
+			if !strings.HasPrefix(got.FileName, tt.want.FileName) {
 				t.Errorf("NewCache() = %v, want %v", got, tt.want)
 			}
 		})
@@ -78,9 +85,14 @@ func FuzzNewCache(f *testing.F) {
 	}
 	f.Fuzz(
 		func(t *testing.T, filename string, lifetime int) {
-			c := NewCache(filename, time.Duration(lifetime))
+			c, err := NewCache(filename, time.Duration(lifetime))
+
+			if err != nil {
+				t.Error("NewCache() errored out:", err.Error())
+			}
+
 			want := CacheFolder + filename
-			if c.FileName != want {
+			if !strings.HasPrefix(c.FileName, want) {
 				t.Errorf("NewCache().FileName = %v, want %v", c.FileName, want)
 			}
 		},

--- a/pkg/scrapper_test.go
+++ b/pkg/scrapper_test.go
@@ -78,7 +78,8 @@ func TestScraper_CreateScraper(t *testing.T) {
 			s := &Scraper{
 				cfg: tt.fields.cfg,
 			}
-			got := s.CreateScraper(tt.args.job, tt.args.cacheExpiryDuration)
+
+			got := s.CreateScraper(tt.args.job, &tt.args.cacheExpiryDuration)
 			d, derr := got()
 			r, terr := tt.want()
 			if (derr != nil) != tt.wantErr {


### PR DESCRIPTION
## Describe changes

When using aqe with multiple accounts, once the same metric is scraped across more than one account (job) it overrides the previous cache as the cache is only differentiated by the job's service code. This results in no errors in the logs however upon scraping, the same label set and values are read from the cache for each job and thus:
```
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Thu, 25 Jan 2024 15:48:13 GMT
Content-Length: 1813

An error has occurred while serving metrics:

5 error(s) occurred:
* collected metric "aws_quota_acm_domain_names_per_acm_certificate" { label:<name:"account" value:"0123456789012" > label:<name:"adjustable" value:"true" > label:<name:"global_quota" value:"false" > label:<name:"region" value:"eu-west-2" > label:<name:"unit" value:"None" > gauge:<value:10 > } was collected before with the same name and label values
* collected metric "aws_quota_acm_acm_certificates" { label:<name:"account" value:"0123456789012" > label:<name:"adjustable" value:"true" > label:<name:"global_quota" value:"false" > label:<name:"region" value:"eu-west-2" > label:<name:"unit" value:"None" > gauge:<value:2500 > } was collected before with the same name and label values
(...)
```

This PR changes this behaviour such that the cache filenames are unique (by using `os.CreateTemp()`).

Cache initialisation is now done earlier during the process and a failure makes the cache `nil` for which the scraper now checks such that if the cache failed to initialise it is not even considered and fresh metrics are always returned.

As part of working on this (and the tests) I've realised that the test success depended on how they were ran as the cache directory was created in main.go. The directories existence is now ensured by `NewCache()` instead.

## Pull Request Checklist

- [x] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [x] Run `pre-commit run -a` on your branch
- [x] Update your branch `git merge main`
- [ ] Update documentation
  - n/a
