### PR TITLE
Add usage metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.7
 	github.com/aws/aws-sdk-go-v2/config v1.18.19
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.18
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.17.3
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.14.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.7
 	github.com/prometheus/client_golang v1.14.0
@@ -23,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.6 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
+	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.44.245 h1:KtY2s4q31/kn33AdV63R5t77mdxsI7rq3YT7Mgo805M=
 github.com/aws/aws-sdk-go v1.44.245/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
 github.com/aws/aws-sdk-go-v2 v1.17.7 h1:CLSjnhJSTSogvqUGhIC6LqFKATMRexcxLZ0i/Nzk9Eg=
 github.com/aws/aws-sdk-go-v2 v1.17.7/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/config v1.18.19 h1:AqFK6zFNtq4i1EYu+eC7lcKHYnZagMn6SW171la0bGw=
@@ -48,12 +49,16 @@ github.com/aws/aws-sdk-go-v2/credentials v1.13.18 h1:EQMdtHwz0ILTW1hoP+EwuWhwCG1
 github.com/aws/aws-sdk-go-v2/credentials v1.13.18/go.mod h1:vnwlwjIe+3XJPBYKu1et30ZPABG3VaXJYr8ryohpIyM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1 h1:gt57MN3liKiyGopcqgNzJb2+d9MJaKT/q1OksHNXVE4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1/go.mod h1:lfUx8puBRdM5lVVMQlwt2v+ofiG/X6Ms+dy0UkG/kXw=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9/go.mod h1:AnVH5pvai0pAF4lXRq0bmhbes1u9R8wTE+g+183bZNM=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.31 h1:sJLYcS+eZn5EeNINGHSCRAwUJMFVqklwkH36Vbyai7M=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.31/go.mod h1:QT0BqUvX1Bh2ABdTGnjqEjvjzrCfIniM9Sc8zn9Yndo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.3/go.mod h1:ssOhaLpRlh88H3UmEcsBoVKq309quMvm3Ds8e9d4eJM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.25 h1:1mnRASEKnkqsntcxHaysxwgVoUUp5dkiB+l3llKnqyg=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.25/go.mod h1:zBHOPwhBc3FlQjQJE/D3IfPWiWaQmT06Vq9aNukDo0k=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.32 h1:p5luUImdIqywn6JpQsW3tq5GNOxKmOnEpybzPx+d1lk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.32/go.mod h1:XGhIBZDEgfqmFIugclZ6FU7v75nHhBDtzuB4xB/tEi4=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.17.3 h1:3q8YzQF2nMvSWbaxoLez1ddN6qo1M1smGrZ+eLb8jqg=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.17.3/go.mod h1:Z+8JhhltQDM1vIHvEtQLr1wVVAqQVLpvCDMVqYBrwr8=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25 h1:5LHn8JQ0qvjD9L9JhMtylnkcw7j05GDZqM9Oin6hpr0=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25/go.mod h1:/95IA+0lMnzW6XzqYJRpjjsAbKEORVeO0anQqjd2CNU=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.14.7 h1:HYGdUZ0XwZ4G6Fyy9w3UxTUHbCIbtYhlVOY6jAj1sXY=
@@ -64,8 +69,10 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.6 h1:B8cauxOH1W1v7rd8RdI/MWno
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.6/go.mod h1:Lh/bc9XUf8CfOY6Jp5aIkQtN+j1mc+nExc+KXj9jx2s=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.7 h1:bWNgNdRko2x6gqa0blfATqAZKZokPIeM1vfmQt2pnvM=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.7/go.mod h1:JuTnSoeePXmMVe9G8NcjjwgOKEfZ4cOjMuT2IBT/2eI=
-github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
+github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
+github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -138,6 +145,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/kubernetes/helm/aqe/values.yaml
+++ b/kubernetes/helm/aqe/values.yaml
@@ -126,6 +126,16 @@ serviceMonitor:
   metricRelabelings: []
   relabelings: []
 
+serviceMonitor:
+  # Specifies whether a ServiceMonitor should be created
+  create: false
+  interval:
+  scrapeTimeout:
+  namespace:
+  additionalLabels: {}
+  metricRelabelings: []
+  relabelings: []
+
 prometheus:
   enabled: true
   serverFiles:

--- a/pkg/scrapper.go
+++ b/pkg/scrapper.go
@@ -4,6 +4,7 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -157,6 +158,7 @@ func (s *Scraper) getAWSConfig(role string) aws.Config {
 	cfg.Credentials = aws.NewCredentialsCache(creds)
 	return cfg
 }
+
 func validateRoleARN(role string) bool {
 	if arn.IsARN(role) {
 		arnObj, err := arn.Parse(role)
@@ -176,34 +178,67 @@ func Transform(quotas *sq.ListServiceQuotasOutput, defaultQuotas *sq.ListAWSDefa
 	check := map[string]bool{}
 
 	for _, v := range quotas.Quotas {
-		metricName := createMetricName(*v.ServiceCode, *v.QuotaName)
+
+		metricName, metricDescription, extraLabels := convertQuotaToMetric(*v.ServiceCode, *v.QuotaName)
+
+		labels := map[string]string{"adjustable": strconv.FormatBool(v.Adjustable), "global_quota": strconv.FormatBool(v.GlobalQuota), "unit": *v.Unit, "region": region, "account": account}
+		maps.Copy(labels, extraLabels)
 
 		metric := &PrometheusMetric{
 			Name:   metricName,
 			Value:  *v.Value,
-			Labels: map[string]string{"adjustable": strconv.FormatBool(v.Adjustable), "global_quota": strconv.FormatBool(v.GlobalQuota), "unit": *v.Unit, "region": region, "account": account},
-			Desc:   *v.QuotaName,
+			Labels: labels,
+			Desc:   metricDescription,
 		}
+
 		metrics = append(metrics, metric)
 		check[metricName] = true
 	}
+
 	for _, d := range defaultQuotas.Quotas {
-		metricName := createMetricName(*d.ServiceCode, *d.QuotaName)
+
+		metricName, metricDescription, extraLabels := convertQuotaToMetric(*d.ServiceCode, *d.QuotaName)
+
+		labels := map[string]string{"adjustable": strconv.FormatBool(d.Adjustable), "global_quota": strconv.FormatBool(d.GlobalQuota), "unit": *d.Unit, "region": region, "account": account}
+		maps.Copy(labels, extraLabels)
+
 		if _, ok := check[metricName]; !ok {
 			metric := &PrometheusMetric{
 				Name:   metricName,
 				Value:  *d.Value,
-				Labels: map[string]string{"adjustable": strconv.FormatBool(d.Adjustable), "global_quota": strconv.FormatBool(d.GlobalQuota), "unit": *d.Unit, "region": region, "account": account},
-				Desc:   *d.QuotaName,
+				Labels: labels,
+				Desc:   metricDescription,
 			}
+
 			metrics = append(metrics, metric)
 		}
 	}
 	return metrics, nil
 }
 
-func createMetricName(serviceCode, quotaName string) string {
-	return fmt.Sprintf("aws_quota_%s_%s", serviceCode, PromString(quotaName))
+func convertQuotaToMetric(serviceCode string, quotaName string) (string, string, map[string]string) {
+	labels := make(map[string]string)
+
+	// check if the metric has a known transformation
+	if _, ok := transformers[serviceCode]; ok {
+		for _, transformer := range transformers[serviceCode] {
+			matches := transformer.re.FindStringSubmatch(quotaName)
+
+			// if transformer found a match, extract all named capture groups into labels
+			if len(matches) > 0 {
+				for _, label := range transformer.re.SubexpNames() {
+					if label != "" {
+						value := transformer.re.SubexpIndex(label)
+						labels[label] = matches[value]
+					}
+				}
+
+				return fmt.Sprintf("aws_quota_%s_%s", serviceCode, PromString(transformer.name)), transformer.name, labels
+			}
+		}
+	}
+
+	return fmt.Sprintf("aws_quota_%s_%s", serviceCode, PromString(quotaName)), quotaName, labels
 }
 
 func getServiceQuotas(ctx context.Context, region, account string, sqInput *sq.ListServiceQuotasInput, client *sq.Client, c chan chanData) {

--- a/pkg/transformer.go
+++ b/pkg/transformer.go
@@ -1,0 +1,138 @@
+package pkg
+
+import "regexp"
+
+// transformer combines a dimension-less metric name and a regular expression pattern.
+//
+// The regex is used to extract dimensions from an AWS quota name whereas the name
+// is generalised to exclude dimensions and used as the metric name.
+type transformer struct {
+	name string
+	re   *regexp.Regexp
+}
+
+// transformers is a map of service codes to defined transformer structs.
+//
+// This allows for reducing the number of regexes parsed when transforming a metric
+// by limiting the search space to the quotas service.
+// The names of capture groups in the regex are used as label names.
+var transformers = map[string][]transformer{
+	"ec2": {
+		{
+			name: "Running Dedicated Hosts",
+			re:   regexp.MustCompile(`^Running Dedicated (?P<instance_family>[\w\s,-]+) Hosts$`),
+		},
+		{
+			name: "Running On-Demand instances",
+			re:   regexp.MustCompile(`^Running On-Demand (?P<instance_class>[\(\w\s,\)-]+) instances$`),
+		},
+		{
+			name: "All Spot Instance Requests",
+			re:   regexp.MustCompile(`^All (?P<instance_class>[\(\w\s,\)-]+) Spot Instance Requests$`),
+		},
+	},
+	"cloudtrail": {
+		{
+			name: "Transactions per second",
+			re:   regexp.MustCompile(`^Transactions per second \(TPS\) for (the )?(?P<api>[\w\s,]+) API(s)?$`),
+		},
+	},
+	"ebs": {
+		{
+			name: "Concurrent snapshots per volume",
+			re:   regexp.MustCompile(`^Concurrent snapshots per (?P<volume_type_name>[\w\s]+) \((?P<volume_type>[\w]+)\) volume$`),
+		},
+		{
+			name: "IOPS for Provisioned IOPS SSD volumes",
+			re:   regexp.MustCompile(`^IOPS for Provisioned IOPS SSD \((?P<volume_type>[\w]+)\) volumes$`),
+		},
+		{
+			name: "IOPS modifications for Provisioned IOPS SSD volumes",
+			re:   regexp.MustCompile(`^IOPS modifications for Provisioned IOPS SSD \((?P<volume_type>[\w]+)\) volumes$`),
+		},
+		{
+			name: "Storage for volumes in TiB",
+			re:   regexp.MustCompile(`^Storage for (?P<volume_type_name>[\w\s]+) \((?P<volume_type>[\w]+)\) volumes, in TiB$`),
+		},
+		{
+			name: "Storage modifications for volumes in TiB",
+			re:   regexp.MustCompile(`^Storage modifications for (?P<volume_type_name>[\w\s]+) \((?P<volume_type>[\w]+)\) volumes, in TiB$`),
+		},
+	},
+	"ecr": {
+		{
+			name: "Rate of requests",
+			re:   regexp.MustCompile(`^Rate of (?P<request_type>[\w]+) requests$`),
+		},
+	},
+	"elasticloadbalancing": {
+		{
+			name: "Listeners per load balancer type",
+			re:   regexp.MustCompile(`^Listeners per (?P<type>\w+) Load Balancer$`),
+		},
+	},
+	"kms": {
+		{
+			name: "Cryptographic operation request rate",
+			re:   regexp.MustCompile(`^Cryptographic operations \((?P<key_type>\w+)\) request rate$`),
+		},
+		{
+			name: "GenerateDataKeyPair request rate",
+			re:   regexp.MustCompile(`^GenerateDataKeyPair \((?P<key_spec>\w+)\) request rate$`),
+		},
+		{
+			name: "Request rate",
+			re:   regexp.MustCompile(`^(?P<operation>\w+) request rate$`),
+		},
+	},
+	"logs": {
+		{
+			name: "Throttle limit in transactions per second",
+			re:   regexp.MustCompile(`^(?P<operation>\w+) throttle limit in transactions per second$`),
+		},
+	},
+	"sagemaker": {
+		{
+			name: "Endpoint usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for endpoint usage$`),
+		},
+		{
+			name: "Notebook instance usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for notebook instance usage$`),
+		},
+		{
+			name: "Processing job usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for processing job usage$`),
+		},
+		{
+			name: "Spot training job usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for spot training job usage$`),
+		},
+		{
+			name: "Training job usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for training job usage$`),
+		},
+		{
+			name: "Training warm pool usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for training warm pool usage$`),
+		},
+		{
+			name: "Transform job usage",
+			re:   regexp.MustCompile(`^(?P<instance_type>[\w\.]+) for transform job usage$`),
+		},
+		{
+			name: "Rate of requests",
+			re:   regexp.MustCompile(`^Rate of (?P<operation>\w+) requests$`),
+		},
+		{
+			name: "Apps running",
+			re:   regexp.MustCompile(`^(?P<app_type>[\w\s]+) running on (?P<instance_type>[\w.]+) instances?$`),
+		},
+	},
+	"servicequotas": {
+		{
+			name: "Throttle rate",
+			re:   regexp.MustCompile(`^Throttle rate for (?P<operation>[\w]+)$`),
+		},
+	},
+}


### PR DESCRIPTION
## Describe changes
Hello, it's me again :)

I've been working on getting the _usage_ metrics pulled in together with the quotas as the API response from AWS does include a `MetricInfo` object which for certain support quotas provides all the values necessary to fetch the current usage level for these quotas. While those metrics are obtainable via other exporters I thought it would make sense for the quota exporter to provide both the limits and the usage when possible.

This is just a draft of a minimal, working PoC - let me know if this kind of feature is something you'd be interested in and I'll keep polishing this. In particular I've been wondering about doing a little bit of refactoring to move some of the AWS specifics into `Scraper` (eg. the region but also the two clients (sq and cw)) to clean things up a little bit and avoid having to pass these around as variables or pointers - let me know if that's a change you'd be happy to see as part of this.

This PR builds atop of #136 (which is pending review at the moment), one of the reasons I've marked this as a draft for now - made it much easier for me to test things before submitting - but it could be separated out if need be.

## Pull Request Checklist

- [x] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [x] Run `pre-commit run -a` on your branch
- [x] Update your branch `git merge main`
- [x] Update documentation
