### PR TITLE
fix: Use 1h window to collect RDS usage metrics

### DIFF
--- a/pkg/scrapper.go
+++ b/pkg/scrapper.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+        defaultCloudwatchTimePeriod = int32(15) // minutes, there can be up to 15 min delay in CloudWatch
 	maxSimilarity = 0.53
 )
 
@@ -375,9 +376,9 @@ func getQuotasUsage(ctx context.Context, quotas []sqTypes.ServiceQuota, cwclient
 		mq := QuotaUsage{q, 0}
 		if q.UsageMetric != nil && !check[*q.QuotaCode] {
 			var dimensions []cwTypes.Dimension
-			var cloudwatchTimePeriod int32 = 15 // minutes, there can be up to 15 min delay in CloudWatch
+			var cloudwatchTimePeriod int32 = defaultCloudwatchTimePeriod
 			if *q.ServiceCode == "rds" {
-				cloudwatchTimePeriod = 60 + 15 // minutes, increased due to delay in RDS usage metrics reporting
+				cloudwatchTimePeriod = 75 // minutes, increased due to delay in RDS usage metrics reporting
 			}
 			for k, v := range q.UsageMetric.MetricDimensions { // form Dimensions filter for GetMetricStatisticsInput based on UsageMetric.MetricDimensions
 				dimensions = append(dimensions, cwTypes.Dimension{Name: aws.String(k), Value: aws.String(v)})

--- a/pkg/scrapper_test.go
+++ b/pkg/scrapper_test.go
@@ -196,9 +196,10 @@ func Test_getQuotasUsage(t *testing.T) {
 				ctx: context.TODO(),
 				quotas: []sqTypes.ServiceQuota{
 					{
-						QuotaCode: aws.String("L-12345"),
-						QuotaName: aws.String("Test Quota"),
-						Value:     aws.Float64(100),
+						ServiceCode: aws.String("test"),
+						QuotaCode:   aws.String("L-12345"),
+						QuotaName:   aws.String("Test Quota"),
+						Value:       aws.Float64(100),
 						UsageMetric: &sqTypes.MetricInfo{
 							MetricName:                    aws.String("CPUUtilization"),
 							MetricNamespace:               aws.String("AWS/EC2"),
@@ -212,9 +213,10 @@ func Test_getQuotasUsage(t *testing.T) {
 			want: []QuotaUsage{
 				{
 					Quota: sqTypes.ServiceQuota{
-						QuotaCode: aws.String("L-12345"),
-						QuotaName: aws.String("Test Quota"),
-						Value:     aws.Float64(100),
+						ServiceCode: aws.String("test"),
+						QuotaCode:   aws.String("L-12345"),
+						QuotaName:   aws.String("Test Quota"),
+						Value:       aws.Float64(100),
 						UsageMetric: &sqTypes.MetricInfo{
 							MetricName:                    aws.String("CPUUtilization"),
 							MetricNamespace:               aws.String("AWS/EC2"),

--- a/pkg/scrapper_test.go
+++ b/pkg/scrapper_test.go
@@ -172,9 +172,10 @@ func Test_getQuotasUsage(t *testing.T) {
 				ctx: context.TODO(),
 				quotas: []sqTypes.ServiceQuota{
 					{
-						QuotaCode: aws.String("L-12345"),
-						QuotaName: aws.String("Test Quota"),
-						Value:     aws.Float64(100),
+						ServiceCode: aws.String("test"),
+						QuotaCode:   aws.String("L-12345"),
+						QuotaName:   aws.String("Test Quota"),
+						Value:       aws.Float64(100),
 					},
 				},
 				region: "us-west-2",
@@ -182,9 +183,10 @@ func Test_getQuotasUsage(t *testing.T) {
 			want: []QuotaUsage{
 				{
 					Quota: sqTypes.ServiceQuota{
-						QuotaCode: aws.String("L-12345"),
-						QuotaName: aws.String("Test Quota"),
-						Value:     aws.Float64(100),
+						ServiceCode: aws.String("test"),
+						QuotaCode:   aws.String("L-12345"),
+						QuotaName:   aws.String("Test Quota"),
+						Value:       aws.Float64(100),
 					},
 					Usage: 0,
 				},


### PR DESCRIPTION
## Linked Issue

fixes: #203

## Describe changes

* Use 1h window to collect RDS usage metrics
* Lower default cloudwatch timeframe to 15 minutes
*  Fix Test_getQuotasUsage/Test_with_quotas_with_usage_metrics

## Pull Request Checklist

- [x] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [x] Run `pre-commit run -a` on your branch
- [x] Update your branch `git merge main`
- [x] Update documentation
