### PR TITLE
fix: Take into account Quota.Period for Sum usage metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+aws_quota_exporter
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
## Linked Issue

closes #211

## Describe changes

Right now it's hardcoded to seconds, but there're metrics reported in minutes. Tested changes on subset of accounts/services, with these changes exporter reports correct values.

Also added binary to .gitignore to avoid accidental commit


## Pull Request Checklist

- [x] Review the [Contributing guidelines](CODE_OF_CONDUCT.md)
- [x] Run `pre-commit run -a` on your branch
- [x] Update your branch `git merge main`
- [x] Update documentation
